### PR TITLE
fix: disable index file generation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,7 +78,6 @@ nav:
 
 plugins:
   - search:
-      prebuild_index: true
   - minify:
       minify_html: true
       minify_js: true


### PR DESCRIPTION
Disabled generation of the search index cache, as it was causing the
github workflow to fail.